### PR TITLE
Fix mobile navigation logo alignment

### DIFF
--- a/wtw/dashboard.php
+++ b/wtw/dashboard.php
@@ -341,13 +341,17 @@ if (session_status() === PHP_SESSION_NONE) {
     .menu-trigger {
         display: inline-flex;
         order: 1;
+        margin-right: auto;
     }
 
     .dashboard-logo {
         order: 2;
-        margin: 0 auto;
         padding: 0;
         --wyw-brand-size: clamp(1.2rem, 6vw, 1.6rem);
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
     }
 
     .dashboard-logo .wyw-brand__where,
@@ -363,7 +367,7 @@ if (session_status() === PHP_SESSION_NONE) {
 
     .user-menu {
         order: 3;
-        margin-left: 0;
+        margin-left: auto;
     }
 
     .user-menu__link {


### PR DESCRIPTION
## Summary
- Center the navigation logo on small screens by absolutely positioning the brand mark within the mobile header.
- Keep the menu trigger and user controls anchored to the edges so the header remains balanced on mobile devices.

## Testing
- php -S 0.0.0.0:8000 -t wtw *(fails: Database connection error in local environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a2b4800883218884202116990089