### PR TITLE
Improve container wrap responsiveness on mobile

### DIFF
--- a/wtw/css/style.css
+++ b/wtw/css/style.css
@@ -244,6 +244,8 @@ body{
                 linear-gradient(160deg, #0a0a0f 0%, #120510 50%, #1a0b16 100%);
     background-size: 200% 200%;
     animation: moveGradient 7s ease-in-out infinite;
+    display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     text-align: center;
@@ -278,6 +280,10 @@ body{
     gap: clamp(12px, 2.4vw, 28px);
     max-width: min(540px, 78%);
     margin: 0 auto;
+}
+
+.backdropContainer--highlight .highlight-card {
+    margin: auto;
 }
 
 .highlight-card__eyebrow {
@@ -481,6 +487,10 @@ body{
     letter-spacing: 0.02em;
     text-transform: uppercase;
     line-height: 0.95;
+}
+
+.hero-card__title--mobile {
+    display: none;
 }
 
 .hero-card__subtitle {
@@ -699,10 +709,14 @@ body{
 }
 
 @media (max-width: 1100px) {
+    #container-wrap {
+        max-height: 750px;
+    }
+
     .backdropContainer {
         height: auto;
         min-height: clamp(380px, 62vh, 560px);
-        max-height: none;
+        max-height: 720px;
     }
 
     .hero-card__layout {
@@ -723,6 +737,20 @@ body{
 @media (max-width: 900px) {
     #container-wrap {
         gap: 20px;
+    }
+
+    .hero-card__title-logo,
+    .hero-card__brand-row {
+        display: none;
+    }
+
+    .hero-card__title--mobile {
+        display: block;
+    }
+
+    .hero-card__title-block {
+        align-items: center;
+        text-align: center;
     }
 
     .row {
@@ -837,7 +865,15 @@ body{
         width: clamp(210px, 58vw, 280px);
         margin: 0 auto;
     }
-}@media (max-width: 560px) {
+}
+
+@media (max-width: 680px) {
+    .hero-card__meta-item--runtime {
+        display: none;
+    }
+}
+
+@media (max-width: 560px) {
     .backdropContainer {
         border-radius: 26px;
     }
@@ -848,6 +884,10 @@ body{
 
     .hero-card__poster-img {
         width: clamp(180px, 60vw, 220px);
+    }
+
+    .hero-card__overview {
+        display: none;
     }
 }
 

--- a/wtw/js/container.js
+++ b/wtw/js/container.js
@@ -553,8 +553,10 @@ document.addEventListener('DOMContentLoaded', function() {
                                 ? imageData.logos.find(logo => logo.file_path)?.file_path
                                 : null;
                             const titleLogoUrl = titleLogoPath ? `https://image.tmdb.org/t/p/w500${titleLogoPath}` : '';
-                            const showTextTitle = !titleLogoUrl;
-                            const showOriginalSubtitle = showTextTitle && originalTitle && originalTitle !== titleSource;
+                            const hasReadableTitle = Boolean(titleSource && titleSource.trim());
+                            const shouldRenderFallbackTitle = !titleLogoUrl && hasReadableTitle;
+                            const shouldRenderMobileTitle = Boolean(titleLogoUrl && hasReadableTitle);
+                            const showOriginalSubtitle = shouldRenderFallbackTitle && originalTitle && originalTitle !== titleSource;
 
                             let runtime = '';
                             if (itemMediaType === 'movie' && data.runtime) {
@@ -597,13 +599,14 @@ document.addEventListener('DOMContentLoaded', function() {
                                             ${primaryCompanyName ? `<span class="hero-card__eyebrow">${primaryCompanyName}</span>` : `<span class="hero-card__eyebrow">Bombando agora</span>`}
                                             <div class="hero-card__title-block">
                                                 ${titleLogoUrl ? `<img src="${titleLogoUrl}" alt="${titleSource}" class="hero-card__title-logo">` : ''}
-                                                ${showTextTitle ? `<h2 class="hero-card__title">${titleSource}</h2>` : ''}
+                                                ${shouldRenderFallbackTitle ? `<h2 class="hero-card__title">${titleSource}</h2>` : ''}
+                                                ${shouldRenderMobileTitle ? `<h2 class="hero-card__title hero-card__title--mobile">${titleSource}</h2>` : ''}
                                                 ${showOriginalSubtitle ? `<p class="hero-card__subtitle">${originalTitle}</p>` : ''}
                                             </div>
                                             <div class="hero-card__meta">
                                                 <span class="hero-card__badge">${mediaTypeTxt}</span>
                                                 ${releaseYear ? `<span class="hero-card__meta-item">${releaseYear}</span>` : ''}
-                                                ${runtime ? `<span class="hero-card__meta-item">${runtime}</span>` : ''}
+                                                ${runtime ? `<span class="hero-card__meta-item hero-card__meta-item--runtime">${runtime}</span>` : ''}
                                                 ${voteAverage ? `<span class="hero-card__meta-item hero-card__meta-item--rating"><img src="imagens/star-emoji.png" alt="" aria-hidden="true">${voteAverage}</span>` : ''}
                                             </div>
                                             ${''}


### PR DESCRIPTION
## Summary
- center the highlight card content and adjust hero titles so text is available when logos are hidden on small screens
- hide hero logos and runtime on mobile/tablet layouts while capping container-wrap height around laptop widths
- suppress long descriptions on mobile and keep desktop layouts unchanged

## Testing
- php -S 0.0.0.0:8000 -t wtw

------
https://chatgpt.com/codex/tasks/task_e_68e1aa1868ec8321b59bbb0c91c2ee1e